### PR TITLE
delete never used project_dir functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,29 +4,6 @@ project_runpy
 Generic helpers I wish existed or am constantly copying into my Python projects.
 
 
-``create_project_dir``
-----------------------
-
-When you need to build an absolute path but only feel like providing a relative
-path.
-
-Example Usage::
-
-    from project_runpy import create_project_dir
-
-    _ = create_project_dir()
-    DATABASE = _('project.db')
-
-    _ = create_project_dir('..')
-    STATIC_ROOT = _('static_root')
-
-    _ = create_project_dir('..', '..')
-    LOCATION = _('FOO', 'BAR', '..', 'BAZ')
-
-Pass the path to get to your project root into ``create_project_dir``, then use
-the function it returns to turn relative paths into absolute paths.
-
-
 ``env``
 -------
 

--- a/project_runpy/tim.py
+++ b/project_runpy/tim.py
@@ -1,39 +1,10 @@
 """
 Tim: Helpers related to functionality.
 """
-import inspect
 import os
 
 
-__all__ = ['create_project_dir', 'ImproperlyConfigured', 'env', ]
-
-
-def create_project_dir(*project_paths):
-    """
-    Get a function you can use to turn relative paths into absolute paths.
-
-    Usage::
-
-        from project_runpy.tim import create_project_dir
-
-        _ = create_project_dir()
-        DATABASE = _('project.db')
-
-        _ = create_project_dir('..')
-        STATIC_ROOT = _('static_root')
-
-        _ = create_project_dir('..', '..')
-        LOCATION = _('FOO', 'BAR', '..', 'BAZ')
-
-    """
-    callee_file = inspect.getouterframes(inspect.currentframe())[1][1]
-    base = os.path.realpath(
-            os.path.join(os.path.dirname(callee_file), *project_paths))
-
-    def project_dir(*paths):
-        return os.path.realpath(os.path.join(base, *paths))
-
-    return project_dir
+__all__ = ['ImproperlyConfigured', 'env', ]
 
 
 class ImproperlyConfigured(Exception):

--- a/tests.py
+++ b/tests.py
@@ -9,25 +9,10 @@ import os
 
 from project_runpy import (
     ColorizingStreamHandler,
-    create_project_dir,
     env,
     ImproperlyConfigured,
     ReadableSqlFilter,
 )
-
-
-class TestTimProjectDir(TestCase):
-    def test_can_build_guess(self):
-        project_dir_func = create_project_dir()
-        dir = os.path.dirname(__file__)
-        self.assertEqual(project_dir_func(), dir)
-        self.assertEqual(project_dir_func('.'), dir)
-        self.assertEqual(project_dir_func('..', 'project_runpy'), dir)
-
-    def test_can_set_start_path(self):
-        project_dir_func = create_project_dir('project_runpy')
-        dir = os.path.dirname(__file__)
-        self.assertEqual(project_dir_func('..'), dir)
 
 
 class TestTimEnv(TestCase):


### PR DESCRIPTION
I found another package that does the same thing, but I can't remember
the name :( it was in some django settings guide.
