### PR TITLE
feat: Update to Django v2 and drop Python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.7"
   - "3.6"
   - "3.5"
-  - "2.7"
 install:
 script: python test_project_runpy.py
 branches:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ install: ## Install requirements
 clean:
 	rm -rf *.egg-info
 	rm -rf dist
-	rm -rf MANIFEST
-	find . -name "*.pyc" -delete
 	find . -name ".DS_Store" -delete
 	find . -name "__pycache__" -delete
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ clean:
 build:
 	flit build
 
+tdd: ## Run test watcher
+	nodemon -e py -x "python test_project_runpy.py --failfast"
+
 test: ## Run test suite
 	coverage erase
 	coverage run test_project_runpy.py

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Turns::
 
 Into::
 
-    (0.002) SELECT ... FROM "tx_elevators_building" LIMIT 21
+    (0.002) SELECT...FROM "tx_elevators_building" LIMIT 21
 
 And when you have many queries, they all line up nicely in your terminal.
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ A logging filter designed to make the ``django.db.backends`` output more
 readable in local dev. This is an alternate to Django Debug Toolbar's SQL panel
 (which, you should be using too) and adds feedback for queries outside HTML.
 
-Django compatibility: Django < 2.0
+Django compatibility: Django >= 2.0
 
 Turns::
 
@@ -108,7 +108,9 @@ Turns::
 
 Into::
 
-    (0.002) SELECT ... FROM "tx_elevators_building" LIMIT 21; args=()
+    (0.002) SELECT ... FROM "tx_elevators_building" LIMIT 21
+
+And when you have many queries, they all line up nicely in your terminal.
 
 To install, edit your Django settings::
 

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,8 @@ Django::
 A logging filter designed to make the ``django.db.backends`` output more
 readable in local dev. This is an alternate to Django Debug Toolbar's SQL panel
 (which, you should be using too) and adds feedback for queries outside HTML.
+This **will slow down** your dev server, but it's a tradeoff for getting faster
+feedback for optimizing your queries.
 
 Django compatibility: Django >= 2.0
 

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ project_runpy
 .. image:: https://travis-ci.org/crccheck/project_runpy.svg
     :target: https://travis-ci.org/crccheck/project_runpy
 
-.. image:: https://coveralls.io/repos/crccheck/project_runpy/badge.png
-    :target: https://coveralls.io/r/crccheck/project_runpy
-
 Generic helpers I wish existed or am constantly copying into my Python projects.
 
 

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -6,12 +6,8 @@ import logging
 __all__ = ['ColorizingStreamHandler', 'ReadableSqlFilter']
 
 
-#
 # Copyright (C) 2010-2012 Vinay Sajip. All rights reserved. Licensed under the new BSD license.
 # https://gist.github.com/758430
-#
-
-
 class ColorizingStreamHandler(logging.StreamHandler):
     # color names to indices
     color_map = {
@@ -84,9 +80,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
         return message
 
 
-###########
-# FILTERS #
-###########
+# LOGGING FILTERS
+#################
 
 class ReadableSqlFilter(logging.Filter):
     """
@@ -94,9 +89,7 @@ class ReadableSqlFilter(logging.Filter):
 
     Modeled after how debug toolbar displays SQL. This code should be optimized
     for performance. For example, I don't check to make sure record.name is
-    'django.db.backends' because I assume you put this filter alongside it. I
-    also assume there is going to be a 'FROM' if there's a 'SELECT' and don't
-    catch the ValueError that would result from that.
+    'django.db.backends' because I assume you put this filter alongside it.
 
     Sample Usage in Django's `settings.py`:
 

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -124,7 +124,7 @@ class ReadableSqlFilter(logging.Filter):
         except ValueError:  # not all SELECT statements also have a FROM
             return super().filter(record)
 
-        sql = u'{0} ... {1}'.format(sql[:begin + 6], sql[end:])
+        sql = '{0} ... {1}'.format(sql[:begin + 6], sql[end:])
         record.msg = '(%.3f) %s'
         record.args = (duration, sql)
         return super().filter(record)

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -124,10 +124,6 @@ class ReadableSqlFilter(logging.Filter):
         except ValueError:  # not all SELECT statements also have a FROM
             return True
 
-        try:
-            very_end = sql.rindex(u'; args') + 1
-        except ValueError:  # msg does not have "args" to strip
-            very_end = None
-        sql = u'{0} ... {1}'.format(sql[:begin + 6], sql[end:very_end])
+        sql = u'{0} ... {1}'.format(sql[:begin + 6], sql[end:])
         record.args = (duration, sql, params)
         return True

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -116,15 +116,15 @@ class ReadableSqlFilter(logging.Filter):
         if 'SELECT' not in sql[:28]:
             # WISHLIST what's the most performant way to see if 'SELECT' was
             # used?
-            return True
+            return super().filter(record)
 
         begin = sql.index('SELECT')
         try:
             end = sql.index('FROM', begin + 6)
         except ValueError:  # not all SELECT statements also have a FROM
-            return True
+            return super().filter(record)
 
         sql = u'{0} ... {1}'.format(sql[:begin + 6], sql[end:])
         record.msg = '(%.3f) %s'
         record.args = (duration, sql)
-        return True
+        return super().filter(record)

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -120,7 +120,7 @@ class ReadableSqlFilter(logging.Filter):
 
         begin = sql.index('SELECT')
         try:
-            end = sql.index('FROM')
+            end = sql.index('FROM', begin + 6)
         except ValueError:  # not all SELECT statements also have a FROM
             return True
 

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -124,7 +124,7 @@ class ReadableSqlFilter(logging.Filter):
         except ValueError:  # not all SELECT statements also have a FROM
             return super().filter(record)
 
-        sql = '{0} ... {1}'.format(sql[:begin + 6], sql[end:])
+        sql = '{0}...{1}'.format(sql[:begin + 6], sql[end:])
         # Drop "; args=%s" to shorten logging output
         record.msg = '(%.3f) %s'
         record.args = (duration, sql)

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -125,6 +125,7 @@ class ReadableSqlFilter(logging.Filter):
             return super().filter(record)
 
         sql = '{0} ... {1}'.format(sql[:begin + 6], sql[end:])
+        # Drop "; args=%s" to shorten logging output
         record.msg = '(%.3f) %s'
         record.args = (duration, sql)
         return super().filter(record)

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -112,7 +112,7 @@ class ReadableSqlFilter(logging.Filter):
 
     def filter(self, record):
         # https://github.com/django/django/blob/febe136d4c3310ec8901abecca3ea5ba2be3952c/django/db/backends/utils.py#L106-L131
-        duration, sql, params = record.args
+        duration, sql, *__ = record.args
         if 'SELECT' not in sql[:28]:
             # WISHLIST what's the most performant way to see if 'SELECT' was
             # used?

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -111,7 +111,7 @@ class ReadableSqlFilter(logging.Filter):
     """
 
     def filter(self, record):
-        # https://github.com/django/django/blob/master/django/db/backends/utils.py
+        # https://github.com/django/django/blob/febe136d4c3310ec8901abecca3ea5ba2be3952c/django/db/backends/utils.py#L106-L131
         duration, sql, params = record.args
         if 'SELECT' not in sql[:28]:
             # WISHLIST what's the most performant way to see if 'SELECT' was
@@ -125,5 +125,6 @@ class ReadableSqlFilter(logging.Filter):
             return True
 
         sql = u'{0} ... {1}'.format(sql[:begin + 6], sql[end:])
-        record.args = (duration, sql, params)
+        record.msg = '(%.3f) %s'
+        record.args = (duration, sql)
         return True

--- a/project_runpy/tim.py
+++ b/project_runpy/tim.py
@@ -70,4 +70,5 @@ class _Env(dict):
                     'Environment variable not found: {0}'.format(key))
         return result
 
+
 env = _Env()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ module = "project_runpy"
 author = "Chris Chang"
 author-email = "c@crccheck.com"
 home-page = "https://github.com/crccheck/project_runpy"
+requires-python="3"
 description-file = "README.rst"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 2.7",
   "Programming Language :: Python :: 3.5",
   "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -148,14 +148,14 @@ class HeidiReadableSqlFilter(TestCase):
         logging_filter = ReadableSqlFilter()
         record = mock.MagicMock(args=(1.0, '(yolo) SELECT foo FROM moo', ()))
         self.assertTrue(logging_filter.filter(record))
-        self.assertIn('SELECT ... FROM moo', record.args[1])
+        self.assertIn('SELECT...FROM moo', record.args[1])
 
     def test_filter_formats_select_from_long(self):
         logging_filter = ReadableSqlFilter()
         original_sql = '(yolo) SELECT {0} FROM moo'.format(VERY_LONG_STRING)
         record = mock.MagicMock(args=(1.0, original_sql, ()))
         self.assertTrue(logging_filter.filter(record))
-        self.assertIn('SELECT ... FROM moo', record.args[1])
+        self.assertIn('SELECT...FROM moo', record.args[1])
 
     def test_filter_formats_ignores_select_without_from(self):
         logging_filter = ReadableSqlFilter()

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -122,15 +122,13 @@ class TestTimEnv(TestCase):
 
 
 class HeidiColorizingStreamHandler(TestCase):
-    def test_it_works(self):
-        # assert can add handler without an exception getting raised
+    def test_it_can_be_added_to_logger(self):
         logger = logging.getLogger('test')
         logger.addHandler(ColorizingStreamHandler())
 
 
 class HeidiReadableSqlFilter(TestCase):
-    def test_it_works(self):
-        # assert can add filter without an exception getting raised
+    def test_it_can_be_added_to_logger(self):
         logger = logging.getLogger('test')
         logger.addFilter(ReadableSqlFilter())
 

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -11,7 +11,7 @@ from project_runpy import (
 )
 
 
-VERY_LONG_STRING = u'*' * 512
+VERY_LONG_STRING = '*' * 512
 
 
 class TestTimEnv(TestCase):
@@ -113,7 +113,7 @@ class TestTimEnv(TestCase):
             env.require('FOO', default='')
 
         with self.assertRaises(ImproperlyConfigured):
-            env.require('FOO', default=u'')
+            env.require('FOO', default='')
 
     def test_require_acts_like_get(self):
         os.environ['FOO'] = 'BAR'
@@ -155,7 +155,7 @@ class HeidiReadableSqlFilter(TestCase):
         original_sql = '(yolo) SELECT {0} FROM moo'.format(VERY_LONG_STRING)
         record = mock.MagicMock(args=(1.0, original_sql, ()))
         self.assertTrue(logging_filter.filter(record))
-        self.assertIn(u'SELECT ... FROM moo', record.args[1])
+        self.assertIn('SELECT ... FROM moo', record.args[1])
 
     def test_filter_formats_ignores_select_without_from(self):
         logging_filter = ReadableSqlFilter()

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -129,8 +129,13 @@ class HeidiColorizingStreamHandler(TestCase):
 
 class HeidiReadableSqlFilter(TestCase):
     def test_it_can_be_added_to_logger(self):
-        logger = logging.getLogger('test')
+        logger = logging.getLogger('foo.sql')
+        logger.addHandler(logging.NullHandler())
         logger.addFilter(ReadableSqlFilter())
+        with self.assertRaises(ValueError):
+            # Sanity check
+            logger.warning('original msg %s %s %s')
+        logger.warning('original msg %s %s %s', '0.1', 'NOT SQL', ())
 
     def test_filter_trivial_case(self):
         logging_filter = ReadableSqlFilter()

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -137,7 +137,9 @@ class HeidiReadableSqlFilter(TestCase):
     def test_filter_trivial_case(self):
         logging_filter = ReadableSqlFilter()
         record = mock.MagicMock(args=())
+        record = mock.MagicMock(args=(1.0, 'foo', ()))
         self.assertTrue(logging_filter.filter(record))
+        self.assertEqual('foo', record.args[1])
 
     def test_filter_formats_select_from(self):
         logging_filter = ReadableSqlFilter()
@@ -147,12 +149,10 @@ class HeidiReadableSqlFilter(TestCase):
 
     def test_filter_formats_select_from_long(self):
         logging_filter = ReadableSqlFilter()
-        record = type('mock_record', (object, ), {
-            'sql': u'SELECT foo',
-            'msg': u'(yolo) SELECT {0} FROM moo'.format(VERY_LONG_STRING),
-        })
+        original_sql = '(yolo) SELECT {0} FROM moo'.format(VERY_LONG_STRING)
+        record = mock.MagicMock(args=(1.0, original_sql, ()))
         self.assertTrue(logging_filter.filter(record))
-        self.assertIn(u'SELECT ... FROM moo', record.msg)
+        self.assertIn(u'SELECT ... FROM moo', record.args[1])
 
     def test_filter_formats_ignores_select_without_from(self):
         logging_filter = ReadableSqlFilter()
@@ -162,22 +162,16 @@ class HeidiReadableSqlFilter(TestCase):
         self.assertEqual(original_sql, record.args[1])
 
     def test_filter_removes_args(self):
-        sql = u"""SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC; args=()"""
         logging_filter = ReadableSqlFilter()
-        record = type('mock_record', (object, ), {
-            'sql': sql,
-            'msg': u'(yolo) {0}'.format(sql),
-        })
+        original_sql = 'SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC; args=()'
+        record = mock.MagicMock(args=(1.0, original_sql, ()))
         self.assertTrue(logging_filter.filter(record))
-        self.assertNotIn('; args=()', record.msg)
+        self.assertNotIn('; args=()', record.args[1])
 
-        # assert it also works when there's no args to begin with
-        sql = u"""SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC"""
+    def test_filter_removes_args_trivial(self):
         logging_filter = ReadableSqlFilter()
-        record = type('mock_record', (object, ), {
-            'sql': sql,
-            'msg': u'(yolo) {0}'.format(sql),
-        })
+        original_sql = 'SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC'
+        record = mock.MagicMock(args=(1.0, original_sql, ()))
         self.assertTrue(logging_filter.filter(record))
         self.assertNotIn('; args=()', record.msg)
 

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -144,23 +144,30 @@ class HeidiReadableSqlFilter(TestCase):
         self.assertTrue(logging_filter.filter(record))
         self.assertEqual('foo', record.args[1])
 
+    def test_filter_params_is_optional(self):
+        logging_filter = ReadableSqlFilter()
+        record = mock.MagicMock(args=())
+        record = mock.MagicMock(args=(1.0, 'foo'))
+        self.assertTrue(logging_filter.filter(record))
+        self.assertEqual('foo', record.args[1])
+
     def test_filter_formats_select_from(self):
         logging_filter = ReadableSqlFilter()
-        record = mock.MagicMock(args=(1.0, '(yolo) SELECT foo FROM moo', ()))
+        record = mock.MagicMock(args=(1.0, '(yolo) SELECT foo FROM moo'))
         self.assertTrue(logging_filter.filter(record))
         self.assertIn('SELECT...FROM moo', record.args[1])
 
     def test_filter_formats_select_from_long(self):
         logging_filter = ReadableSqlFilter()
         original_sql = '(yolo) SELECT {0} FROM moo'.format(VERY_LONG_STRING)
-        record = mock.MagicMock(args=(1.0, original_sql, ()))
+        record = mock.MagicMock(args=(1.0, original_sql))
         self.assertTrue(logging_filter.filter(record))
         self.assertIn('SELECT...FROM moo', record.args[1])
 
     def test_filter_formats_ignores_select_without_from(self):
         logging_filter = ReadableSqlFilter()
         original_sql = '(yolo) SELECT {0} moo'.format(VERY_LONG_STRING)
-        record = mock.MagicMock(args=(1.0, original_sql, ()))
+        record = mock.MagicMock(args=(1.0, original_sql))
         self.assertTrue(logging_filter.filter(record))
         self.assertEqual(original_sql, record.args[1])
 

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -161,16 +161,6 @@ class HeidiReadableSqlFilter(TestCase):
         self.assertTrue(logging_filter.filter(record))
         self.assertEqual(original_sql, record.args[1])
 
-    def test_filter_formats_select_from_dj17(self):
-        sql = u"""QUERY = "\n            SELECT name, {0} FROM sqlite_master\n            WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'\n            ORDER BY name" - PARAMS = ()""".format(VERY_LONG_STRING)
-        logging_filter = ReadableSqlFilter()
-        record = type('mock_record', (object, ), {
-            'sql': sql,
-            'msg': u'(yolo) {0}'.format(sql),
-        })
-        self.assertTrue(logging_filter.filter(record))
-        self.assertNotIn(VERY_LONG_STRING, record.msg)
-
     def test_filter_removes_args(self):
         sql = u"""SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC; args=()"""
         logging_filter = ReadableSqlFilter()

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -159,20 +159,6 @@ class HeidiReadableSqlFilter(TestCase):
         self.assertTrue(logging_filter.filter(record))
         self.assertEqual(original_sql, record.args[1])
 
-    def test_filter_removes_args(self):
-        logging_filter = ReadableSqlFilter()
-        original_sql = 'SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC; args=()'
-        record = mock.MagicMock(args=(1.0, original_sql, ()))
-        self.assertTrue(logging_filter.filter(record))
-        self.assertNotIn('; args=()', record.args[1])
-
-    def test_filter_removes_args_trivial(self):
-        logging_filter = ReadableSqlFilter()
-        original_sql = 'SELECT ... FROM "tx_lobbying_expensedetailreport" GROUP BY "tx_lobbying_expensedetailreport"."year", "tx_lobbying_expensedetailreport"."type" ORDER BY "tx_lobbying_expensedetailreport"."year" ASC'
-        record = mock.MagicMock(args=(1.0, original_sql, ()))
-        self.assertTrue(logging_filter.filter(record))
-        self.assertNotIn('; args=()', record.msg)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
BREAKING CHANGE: Django 2's sql logging format is different, so we need to adapt. Python 2 is also dead to me, so dropping support for that.