### PR TITLE
fix(heidi): fix when there's no sql to format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ test: ## Run test suite
 # Bump project_runpy.__version__
 # Update CHANGELOG (TODO)
 # `git commit -am "1.0.0"`
-# `git tag v1.0.0`
 # `make publish`
+# `git tag v1.0.0`
 # `git push --tags origin master`
 publish: ## Publish a release to PyPI
 	flit publish

--- a/project_runpy/heidi.py
+++ b/project_runpy/heidi.py
@@ -113,7 +113,7 @@ class ReadableSqlFilter(logging.Filter):
     def filter(self, record):
         # https://github.com/django/django/blob/febe136d4c3310ec8901abecca3ea5ba2be3952c/django/db/backends/utils.py#L106-L131
         duration, sql, *__ = record.args
-        if 'SELECT' not in sql[:28]:
+        if not sql or 'SELECT' not in sql[:28]:
             # WISHLIST what's the most performant way to see if 'SELECT' was
             # used?
             return super().filter(record)

--- a/test_project_runpy.py
+++ b/test_project_runpy.py
@@ -144,6 +144,11 @@ class HeidiReadableSqlFilter(TestCase):
         self.assertTrue(logging_filter.filter(record))
         self.assertEqual('foo', record.args[1])
 
+    def test_filter_runs_when_no_sql_exists(self):
+        logging_filter = ReadableSqlFilter()
+        record = mock.MagicMock(args=(0.07724404335021973, None, ()))
+        self.assertTrue(logging_filter.filter(record))
+
     def test_filter_params_is_optional(self):
         logging_filter = ReadableSqlFilter()
         record = mock.MagicMock(args=())


### PR DESCRIPTION
When no `sql` is passed into the logger, the formatter double fails and throws it's own error. That's no good. This fixes it by making sure there's `sql` to format.

Fix #16 